### PR TITLE
delete SUSE 13.2 from Download page

### DIFF
--- a/_posts/2017-04-27-win-mac-deb-release-v58.md
+++ b/_posts/2017-04-27-win-mac-deb-release-v58.md
@@ -2,7 +2,7 @@
 layout: post
 style: style2
 title:  "Version 58.0 now available"
-description: Up-to-date v58.0 builds for Windows, Mac OSX, Ubuntu/Debian, openSUSE and Fedora as well as Red Hat Enterprise Linux 7 now available!
+description: Up-to-date v58.0 builds for Windows, Mac OSX, Ubuntu/Debian, openSUSE and Fedora as well as Red Hat Enterprise Linux now available!
 date:   2017-04-27 11:58:00 +0200
 author:	by admin
 categories: news

--- a/downloads/linux.md
+++ b/downloads/linux.md
@@ -48,11 +48,6 @@ current version 58.0
 	zypper ar https://downloads.iridiumbrowser.de/openSUSE_Leap_42.2/ iridium
 	zypper in iridium-browser
      
-### 13.2 #
-
-	zypper ar https://downloads.iridiumbrowser.de/openSUSE_13.2/ iridium  
-	zypper in iridium-browser
-
 ### Tumbleweed #
 
 	zypper ar https://downloads.iridiumbrowser.de/openSUSE_Tumbleweed/ iridium  


### PR DESCRIPTION
- delete SUSE 13.2 from Linux DL page
- minor updates in last news post