### PR TITLE
Mac OSX / MAC OSX -> macOS

### DIFF
--- a/_footer-downloads/footer-downloads.md
+++ b/_footer-downloads/footer-downloads.md
@@ -9,7 +9,7 @@ title: ""
 [Windows](windows.html "Windows Download Page"){:.button .small .fit .icon .fa-windows}
 </div>
 <div class="4u 12u$(small)">
-[Mac OSX](macosx.html "Mac OSX Download Page"){:.button .small .fit .icon .fa-apple}
+[macOS](macosx.html "macOS Download Page"){:.button .small .fit .icon .fa-apple}
 </div>
 <div class="4u 12u$(small)">
 [Linux](linux.html "Linux Download Page"){:.button .small .fit .icon .fa-linux}
@@ -17,7 +17,7 @@ title: ""
 </div>
 Currently Iridium Browser is available for the following Operating Systems    
 **[Windows 7+](windows.html "Windows 7+") &#8226;
-[Mac OSX 10.9+](macosx.html "Mac OSX 10.9+") &#8226;
+[macOS 10.9+](macosx.html "macOS 10.9+") &#8226;
 [Ubuntu 14.04+ | Debian 8+ | Mint 17+ (all 64-bit)](linux.html "Ubuntu 14.04+ | Debian 8+ | Mint 17+ (all 64-bit)") &#8226;
 [openSUSE Leap 42.1+ | Tumbleweed](linux.html#suse "openSUSE Leap 42.1+ | Tumbleweed") &#8226;
 [Fedora 24+](linux.html#fedora "Fedora 24+") &#8226;

--- a/_manifest/manifest.md
+++ b/_manifest/manifest.md
@@ -10,7 +10,7 @@ Before Iridium Browser, we had to decide if we wanted to have cutting edge techn
 So we decided to use the power of free software and build a browser that can do both. We analysed the code of Chromium and stripped out the functionality which exposes data to others in a way we don‘t like.    
 See most important changes [here](https://github.com/iridium-browser/tracker/wiki/Differences-between-Iridium-and-Chromium "Differences between Iridium and Chromium"){:target="_blank"} 
      
-Our ambition is to get builds for Debian, Ubuntu, openSUSE, fedora, Windows and OS-X a couple of days after a new release of Chromium.   
+Our ambition is to get builds for Debian, Ubuntu, openSUSE, fedora, Windows and macOS a couple of days after a new release of Chromium.
 To achieve this, we need help from individuals and organisations, who have the same intention.
 Currently there are weeks between a new release of Iridium and Chromium.     
 Please take this into consideration for your personal usage of the browser as you might be at risk when surfing unknown and potentially dangerous websites!     

--- a/_marquee/marquee.md
+++ b/_marquee/marquee.md
@@ -3,4 +3,4 @@ layout: default-layout
 title: "Marquee"
 ---
 
-[</> **Now available** Version 61 **for Windows, Mac OSX, openSUSE Leap 42.2, 42.3 and Tumbleweed** - go to **Download section** </>](/downloads/ "download v61 for Windows or Mac OSX")
+[</> **Now available** Version 61 **for Windows, macOS, openSUSE Leap 42.2, 42.3 and Tumbleweed** - go to **Download section** </>](/downloads/ "download v61 for Windows or macOS")

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -2,7 +2,7 @@
 layout: downloads
 title: "Download"
 subtitle: ""
-description: Download Iridium Browser for Windows, Mac OSX, Ubuntu, Debian, Mint, OpenSUSE, Fedora and Red Hat Enterprise Linux
+description: Download Iridium Browser for Windows, macOS, Ubuntu, Debian, Mint, OpenSUSE, Fedora and Red Hat Enterprise Linux
 hotpic-fb: "{{ '/images/hotpics/Iridium-fb_hotpic-download.png' | absolute_url }}"
 hotpic-tw: "{{ '/images/hotpics/Iridium-tw_hotpic-download.png' | absolute_url }}"
 menu: 2
@@ -44,7 +44,7 @@ else { window.location="{{ '/downloads/sorry.html' | relative_url }}"; }
 		"downloadUrl": "{{ '/downloads/' | absolute_url }}",
 		"description": "{{ site.description }}",
 		"applicationCategory": "Browser",
-		"operatingSystem": "Windows, Mac OSX, Ubuntu, Debian, openSUSE, Fedora, Red Hat Enterprise Linux",
+		"operatingSystem": "Windows, macOS, Ubuntu, Debian, openSUSE, Fedora, Red Hat Enterprise Linux",
 		"aggregateRating": {
 			"@type": "AggregateRating",
 			"bestRating": "100",

--- a/downloads/macosx.md
+++ b/downloads/macosx.md
@@ -1,8 +1,8 @@
 ---
 layout: downloads
-title: "Download for Mac OSX"
+title: "Download for macOS"
 subtitle: ""
-description: Download Iridium Browser for Mac OSX 10.9+
+description: Download Iridium Browser for macOS
 hotpic-fb: "/images/hotpics/Iridium-fb_hotpic-dl-osx.png"
 hotpic-tw: "/images/hotpics/Iridium-tw_hotpic-dl-osx.png"
 menu: no
@@ -14,7 +14,7 @@ sitemap:
 {::options parse_block_html="true" /}
 <div class="icon dl fa-apple"></div>
 <header>
-### Mac OSX 10.9+ #
+### macOS #
 current version 2017-10      
 <small>(based on chromium v61)</small>
 </header>
@@ -22,14 +22,14 @@ current version 2017-10
 <div class="container 25%">
 <div class="row">
 <div class="12u$ align-center">
-[Mac OSX Download](https://downloads.iridiumbrowser.de/macosx/iridium_browser_osx_latest.dmg "download Mac OSX Version"){:.button .small .fit .download .icon .fa-download}
+[macOS  Download](https://downloads.iridiumbrowser.de/macosx/iridium_browser_osx_latest.dmg "download macOS Version"){:.button .small .fit .download .icon .fa-download}
 </div>
 </div></div>
 \\
 If you are looking for previous versions, please check out the [Builds Archive](https://downloads.iridiumbrowser.de/macosx/ "go to Builds Archive"){:target="_blank"}<br/>
 \\
 system requirements  
-&#8226; OSX Mavericks 10.9+
+&#8226;  macOS >= 10.9.x
 	 
 ---
 


### PR DESCRIPTION
Mac OSX/OS X is now generally referred to as macOS, so rename it accordingly.
Imho we should rename the path to the download as well (macosx.md -> macos.md), but I'm not sure if this is SEO-relevant...